### PR TITLE
Add support for arrays in systemd Exec fields.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,12 +15,12 @@ systemd_target: {}
 #     pid_file: ""
 #     oom_score_adjust: ""
 #     nice: ""
-#     exec_start: ""
-#     exec_start_pre: ""
-#     exec_start_post: ""
-#     exec_stop: ""
-#     exec_stop_post: ""
-#     exec_reload: ""
+#     exec_start: "" or exec_start: [] (only when oneshot)
+#     exec_start_pre: "" or exec_start_pre: []
+#     exec_start_post: "" or exec_start_post: []
+#     exec_stop: "" or exec_stop: []
+#     exec_stop_post: "" or exec_stop_post: []
+#     exec_reload: "" or exec_reload: []
 #     restart: ""
 #     restart_sec: ""
 #     timeout_sec: 30

--- a/templates/etc/systemd/system/systemd.service.j2
+++ b/templates/etc/systemd/system/systemd.service.j2
@@ -57,48 +57,60 @@ OOMScoreAdjust={{ item.value.oom_score_adjust }}
 Nice={{ item.value.nice }}
 {% endif -%}
 
-{% if item.value.exec_stop is defined and item.value.exec_stop is not string %}
+{% if item.value.exec_stop is defined %}
+{% if item.value.exec_stop is not string %}
 {% for exec_stop in item.value.exec_stop -%}
 ExecStop={{ exec_stop }}
 {% endfor %}
 {% else %}
 ExecStop={{ item.value.exec_stop }}
 {% endif -%}
-{% if item.value.exec_stop_post is defined and item.value.exec_stop_post is not string %}
+{% endif -%}
+{% if item.value.exec_stop_post is defined %}
+{% if item.value.exec_stop_post is not string %}
 {% for exec_stop_post in item.value.exec_stop_post -%}
 ExecStopPost={{ exec_stop_post }}
 {% endfor %}
 {% else %}
 ExecStopPost={{ item.value.exec_stop_post }}
 {% endif -%}
-{% if item.value.exec_reload is defined and item.value.exec_reload is not string %}
+{% endif -%}
+{% if item.value.exec_reload is defined %}
+{% if item.value.exec_reload is not string %}
 {% for exec_reload in item.value.exec_reload -%}
 ExecReload={{ item.value.exec_reload }}
 {% endfor %}
 {% else %}
 ExecReload={{ item.value.exec_reload }}
 {% endif -%}
+{% endif -%}
 
-{% if item.value.exec_start_pre is defined and item.value.exec_start_pre is not string %}
+{% if item.value.exec_start_pre is defined %}
+{% if item.value.exec_start_pre is not string %}
 {% for exec_start_pre in item.value.exec_start_pre -%}
 ExecStartPre={{ exec_start_pre }}
 {% endfor %}
 {% else %}
 ExecStartPre={{ item.value.exec_start_pre }}
 {% endif -%}
-{% if item.value.exec_start_post is defined and item.value.exec_start_post is not string %}
+{% endif -%}
+{% if item.value.exec_start_post is defined %}
+{% if item.value.exec_start_post is not string %}
 {% for exec_start_post in item.value.exec_start_post -%}
 ExecStartPost={{ item.value.exec_start_post }}
 {% endfor %}
 {% else %}
 ExecStartPost={{ item.value.exec_start_post }}
 {% endif -%}
-{% if item.value.exec_start is defined and item.value.exec_start is not string %}
+{% endif -%}
+{% if item.value.exec_start is defined %}
+{% if item.value.exec_start is not string %}
 {% for exec_start in item.value.exec_startt -%}
 ExecStart={{ exec_start }}
 {% endfor %}
 {% else %}
 ExecStart={{ item.value.exec_start }}
+{% endif -%}
 {% endif -%}
 
 {% if item.value.standard_input is defined %}

--- a/templates/etc/systemd/system/systemd.service.j2
+++ b/templates/etc/systemd/system/systemd.service.j2
@@ -57,23 +57,47 @@ OOMScoreAdjust={{ item.value.oom_score_adjust }}
 Nice={{ item.value.nice }}
 {% endif -%}
 
-{% if item.value.exec_stop is defined %}
+{% if item.value.exec_stop is defined and item.value.exec_stop is not string %}
+{% for exec_stop in item.value.exec_stop -%}
+ExecStop={{ exec_stop }}
+{% endfor %}
+{% else %}
 ExecStop={{ item.value.exec_stop }}
 {% endif -%}
-{% if item.value.exec_stop_post is defined %}
+{% if item.value.exec_stop_post is defined and item.value.exec_stop_post is not string %}
+{% for exec_stop_post in item.value.exec_stop_post -%}
+ExecStopPost={{ exec_stop_post }}
+{% endfor %}
+{% else %}
 ExecStopPost={{ item.value.exec_stop_post }}
 {% endif -%}
-{% if item.value.exec_reload is defined %}
+{% if item.value.exec_reload is defined and item.value.exec_reload is not string %}
+{% for exec_reload in item.value.exec_reload -%}
+ExecReload={{ item.value.exec_reload }}
+{% endfor %}
+{% else %}
 ExecReload={{ item.value.exec_reload }}
 {% endif -%}
 
-{% if item.value.exec_start_pre is defined %}
+{% if item.value.exec_start_pre is defined and item.value.exec_start_pre is not string %}
+{% for exec_start_pre in item.value.exec_start_pre -%}
+ExecStartPre={{ exec_start_pre }}
+{% endfor %}
+{% else %}
 ExecStartPre={{ item.value.exec_start_pre }}
 {% endif -%}
-{% if item.value.exec_start_post is defined %}
+{% if item.value.exec_start_post is defined and item.value.exec_start_post is not string %}
+{% for exec_start_post in item.value.exec_start_post -%}
+ExecStartPost={{ item.value.exec_start_post }}
+{% endfor %}
+{% else %}
 ExecStartPost={{ item.value.exec_start_post }}
 {% endif -%}
-{% if item.value.exec_start is defined %}
+{% if item.value.exec_start is defined and item.value.exec_start is not string %}
+{% for exec_start in item.value.exec_startt -%}
+ExecStart={{ exec_start }}
+{% endfor %}
+{% else %}
 ExecStart={{ item.value.exec_start }}
 {% endif -%}
 


### PR DESCRIPTION
This allows one to specify for example `ExecStartPre` as an array:

```
systemd_service:
  service_name:
    [...]
    exec_start_pre:
      - command1
      - command2
    [...]
```

It is backwards compatible (so string/single value is still valid).
Relevant systemd documentation: https://www.freedesktop.org/software/systemd/man/systemd.service.html