### PR TITLE
Ensure daemon reload

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+
+# If defined and set to True, it skips the restart handler
+# systemd_restart_disabled:
+
 systemd_service: {}
 systemd_target: {}
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,4 @@
     state: restarted
     daemon_reload: yes
   with_dict: "{{ systemd_service }}"
+  when: systemd_restart_disabled | default(True)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 galaxy_info:
   author: Eugene Ignatov
   description: Create and configure a systemd service
+  role_name: systemd_service
   company: Cimon.io
   license: MIT
   min_ansible_version: 2.0.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   systemd:
     name: "{{ item.key }}.service"
     enabled: "{{ item.value.enabled | default(False) }}"
+    daemon_reload: yes
   with_dict: "{{ systemd_service }}"
   tags:
     - systemd-service

--- a/templates/etc/systemd/system/systemd.service.j2
+++ b/templates/etc/systemd/system/systemd.service.j2
@@ -86,6 +86,9 @@ StandardOutput={{ item.value.standard_output }}
 {% if item.value.standard_error is defined %}
 StandardError={{ item.value.standard_error }}
 {% endif %}
+{% if item.value.service_extra_opts is defined %}
+{{ item.value.service_extra_opts }}
+{% endif %}
 
 [Install]
 {% if item.value.wanted_by is defined %}


### PR DESCRIPTION
In some scenarios, we have seen that the process leaves systemd daemon without reload new configuration, so with we try to ensure about that.