### PR TITLE
add state variable to specify whether to restart/reload/start/stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ If "tty", "tty-force", or "tty-fail" is specified for any of "standard_*" parame
 tty_path:
 ```
 
+If service should be in restarted/reloaded/started/stopped state after service is created or modified.
+```yaml
+state:
+```
+It can take values: `restarted` (default) `reloaded` `started` `stopped`
+
 ### Install section options
 
 This section variables carry installation information for the unit. The following two parameters can be used more than once, or space-separated lists of unit names may be specified. The lists include units which refers to this service from their `requires` and `wants` fields.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,6 @@
 - name: "restart service"
   systemd:
     name: "{{ item }}.service"
-    state: restarted
+    state: "{{ systemd_service[item].state | default('restarted') }}"
     daemon_reload: yes
   with_items: "{{ systemd_service | list }}"


### PR DESCRIPTION
the created service.

I needed to create a service but did not want to start it automatically after creation/modification. So I added logic to the restart handler so that I could specify what state the service should be. Maybe it is useful to others.